### PR TITLE
Little typo in the cloning link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@
    
    2. Clone the git repository from github:
    
-      `git clone https://github.com/perusio/nginx-wordpress.git`
+      `git clone https://github.com/perusio/wordpress-nginx.git`
    
    3. Edit the `sites-available/example.com.conf` configuration file
       to suit your requirements. Namely replacing `example.com` with


### PR DESCRIPTION
Changed 'nginx-wordpress.git' to 'wordpress-nginx.git'
